### PR TITLE
aspidaでクライアント側のエンドポイントの型を定義

### DIFF
--- a/web/aspida.config.js
+++ b/web/aspida.config.js
@@ -1,0 +1,4 @@
+// aspida.config.js
+module.exports = {
+  input: 'src/libs/api',
+};

--- a/web/package.json
+++ b/web/package.json
@@ -9,9 +9,11 @@
     "lint": "next lint",
     "format": "prettier --write \"./src/**/*.{ts,tsx}\"",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "api:build": "aspida"
   },
   "dependencies": {
+    "@aspida/fetch": "^1.11.0",
     "@dnd-kit/core": "^6.0.7",
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "api:build": "aspida"
   },
   "dependencies": {
-    "@aspida/fetch": "^1.11.0",
+    "@aspida/axios": "^1.11.0",
     "@dnd-kit/core": "^6.0.7",
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",
@@ -21,6 +21,7 @@
     "@types/node": "18.11.18",
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.10",
+    "axios": "^1.3.4",
     "eslint": "8.31.0",
     "eslint-config-next": "13.1.1",
     "next": "13.1.1",

--- a/web/src/libs/api/$api.ts
+++ b/web/src/libs/api/$api.ts
@@ -1,0 +1,23 @@
+import type { AspidaClient } from 'aspida'
+import type { Methods as Methods0 } from './user/login'
+
+const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
+  const prefix = (baseURL === undefined ? '' : baseURL).replace(/\/$/, '')
+  const PATH0 = '/user/login'
+  const POST = 'POST'
+
+  return {
+    user: {
+      login: {
+        post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods0['post']['resBody']>(prefix, PATH0, POST, option).json(),
+        $post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods0['post']['resBody']>(prefix, PATH0, POST, option).json().then(r => r.body),
+        $path: () => `${prefix}${PATH0}`
+      }
+    }
+  }
+}
+
+export type ApiInstance = ReturnType<typeof api>
+export default api

--- a/web/src/libs/api/$api.ts
+++ b/web/src/libs/api/$api.ts
@@ -1,19 +1,46 @@
 import type { AspidaClient } from 'aspida'
-import type { Methods as Methods0 } from './user/login'
+import type { Methods as Methods0 } from './user/delete_user'
+import type { Methods as Methods1 } from './user/get_user_info'
+import type { Methods as Methods2 } from './user/login'
+import type { Methods as Methods3 } from './user/make_user'
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (baseURL === undefined ? '' : baseURL).replace(/\/$/, '')
-  const PATH0 = '/user/login'
+  const PATH0 = '/user/delete_user'
+  const PATH1 = '/user/get_user_info'
+  const PATH2 = '/user/login'
+  const PATH3 = '/user/make_user'
   const POST = 'POST'
 
   return {
     user: {
-      login: {
+      delete_user: {
         post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
           fetch<Methods0['post']['resBody']>(prefix, PATH0, POST, option).json(),
         $post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
           fetch<Methods0['post']['resBody']>(prefix, PATH0, POST, option).json().then(r => r.body),
         $path: () => `${prefix}${PATH0}`
+      },
+      get_user_info: {
+        post: (option: { body: Methods1['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods1['post']['resBody']>(prefix, PATH1, POST, option).json(),
+        $post: (option: { body: Methods1['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods1['post']['resBody']>(prefix, PATH1, POST, option).json().then(r => r.body),
+        $path: () => `${prefix}${PATH1}`
+      },
+      login: {
+        post: (option: { body: Methods2['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods2['post']['resBody']>(prefix, PATH2, POST, option).json(),
+        $post: (option: { body: Methods2['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods2['post']['resBody']>(prefix, PATH2, POST, option).json().then(r => r.body),
+        $path: () => `${prefix}${PATH2}`
+      },
+      make_user: {
+        post: (option: { body: Methods3['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods3['post']['resBody']>(prefix, PATH3, POST, option).json(),
+        $post: (option: { body: Methods3['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods3['post']['resBody']>(prefix, PATH3, POST, option).json().then(r => r.body),
+        $path: () => `${prefix}${PATH3}`
       }
     }
   }

--- a/web/src/libs/api/$api.ts
+++ b/web/src/libs/api/$api.ts
@@ -1,46 +1,97 @@
 import type { AspidaClient } from 'aspida'
-import type { Methods as Methods0 } from './user/delete_user'
-import type { Methods as Methods1 } from './user/get_user_info'
-import type { Methods as Methods2 } from './user/login'
-import type { Methods as Methods3 } from './user/make_user'
+import type { Methods as Methods0 } from './match/after/send_result'
+import type { Methods as Methods1 } from './match/before/custom_match'
+import type { Methods as Methods2 } from './match/before/delete_room'
+import type { Methods as Methods3 } from './match/before/leave_user'
+import type { Methods as Methods4 } from './match/before/random_match'
+import type { Methods as Methods5 } from './user/delete_user'
+import type { Methods as Methods6 } from './user/get_user_info'
+import type { Methods as Methods7 } from './user/login'
+import type { Methods as Methods8 } from './user/make_user'
 
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (baseURL === undefined ? '' : baseURL).replace(/\/$/, '')
-  const PATH0 = '/user/delete_user'
-  const PATH1 = '/user/get_user_info'
-  const PATH2 = '/user/login'
-  const PATH3 = '/user/make_user'
+  const PATH0 = '/match/after/send_result'
+  const PATH1 = '/match/before/custom_match'
+  const PATH2 = '/match/before/delete_room'
+  const PATH3 = '/match/before/leave_user'
+  const PATH4 = '/match/before/random_match'
+  const PATH5 = '/user/delete_user'
+  const PATH6 = '/user/get_user_info'
+  const PATH7 = '/user/login'
+  const PATH8 = '/user/make_user'
   const POST = 'POST'
 
   return {
+    match: {
+      after: {
+        send_result: {
+          post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
+            fetch<Methods0['post']['resBody']>(prefix, PATH0, POST, option).json(),
+          $post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
+            fetch<Methods0['post']['resBody']>(prefix, PATH0, POST, option).json().then(r => r.body),
+          $path: () => `${prefix}${PATH0}`
+        }
+      },
+      before: {
+        custom_match: {
+          post: (option: { body: Methods1['post']['reqBody'], config?: T | undefined }) =>
+            fetch<Methods1['post']['resBody']>(prefix, PATH1, POST, option).json(),
+          $post: (option: { body: Methods1['post']['reqBody'], config?: T | undefined }) =>
+            fetch<Methods1['post']['resBody']>(prefix, PATH1, POST, option).json().then(r => r.body),
+          $path: () => `${prefix}${PATH1}`
+        },
+        delete_room: {
+          post: (option: { body: Methods2['post']['reqBody'], config?: T | undefined }) =>
+            fetch<Methods2['post']['resBody']>(prefix, PATH2, POST, option).json(),
+          $post: (option: { body: Methods2['post']['reqBody'], config?: T | undefined }) =>
+            fetch<Methods2['post']['resBody']>(prefix, PATH2, POST, option).json().then(r => r.body),
+          $path: () => `${prefix}${PATH2}`
+        },
+        leave_user: {
+          post: (option: { body: Methods3['post']['reqBody'], config?: T | undefined }) =>
+            fetch<Methods3['post']['resBody']>(prefix, PATH3, POST, option).json(),
+          $post: (option: { body: Methods3['post']['reqBody'], config?: T | undefined }) =>
+            fetch<Methods3['post']['resBody']>(prefix, PATH3, POST, option).json().then(r => r.body),
+          $path: () => `${prefix}${PATH3}`
+        },
+        random_match: {
+          post: (option: { body: Methods4['post']['reqBody'], config?: T | undefined }) =>
+            fetch<Methods4['post']['resBody']>(prefix, PATH4, POST, option).json(),
+          $post: (option: { body: Methods4['post']['reqBody'], config?: T | undefined }) =>
+            fetch<Methods4['post']['resBody']>(prefix, PATH4, POST, option).json().then(r => r.body),
+          $path: () => `${prefix}${PATH4}`
+        }
+      }
+    },
     user: {
       delete_user: {
-        post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-          fetch<Methods0['post']['resBody']>(prefix, PATH0, POST, option).json(),
-        $post: (option: { body: Methods0['post']['reqBody'], config?: T | undefined }) =>
-          fetch<Methods0['post']['resBody']>(prefix, PATH0, POST, option).json().then(r => r.body),
-        $path: () => `${prefix}${PATH0}`
+        post: (option: { body: Methods5['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods5['post']['resBody']>(prefix, PATH5, POST, option).json(),
+        $post: (option: { body: Methods5['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods5['post']['resBody']>(prefix, PATH5, POST, option).json().then(r => r.body),
+        $path: () => `${prefix}${PATH5}`
       },
       get_user_info: {
-        post: (option: { body: Methods1['post']['reqBody'], config?: T | undefined }) =>
-          fetch<Methods1['post']['resBody']>(prefix, PATH1, POST, option).json(),
-        $post: (option: { body: Methods1['post']['reqBody'], config?: T | undefined }) =>
-          fetch<Methods1['post']['resBody']>(prefix, PATH1, POST, option).json().then(r => r.body),
-        $path: () => `${prefix}${PATH1}`
+        post: (option: { body: Methods6['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods6['post']['resBody']>(prefix, PATH6, POST, option).json(),
+        $post: (option: { body: Methods6['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods6['post']['resBody']>(prefix, PATH6, POST, option).json().then(r => r.body),
+        $path: () => `${prefix}${PATH6}`
       },
       login: {
-        post: (option: { body: Methods2['post']['reqBody'], config?: T | undefined }) =>
-          fetch<Methods2['post']['resBody']>(prefix, PATH2, POST, option).json(),
-        $post: (option: { body: Methods2['post']['reqBody'], config?: T | undefined }) =>
-          fetch<Methods2['post']['resBody']>(prefix, PATH2, POST, option).json().then(r => r.body),
-        $path: () => `${prefix}${PATH2}`
+        post: (option: { body: Methods7['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods7['post']['resBody']>(prefix, PATH7, POST, option).json(),
+        $post: (option: { body: Methods7['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods7['post']['resBody']>(prefix, PATH7, POST, option).json().then(r => r.body),
+        $path: () => `${prefix}${PATH7}`
       },
       make_user: {
-        post: (option: { body: Methods3['post']['reqBody'], config?: T | undefined }) =>
-          fetch<Methods3['post']['resBody']>(prefix, PATH3, POST, option).json(),
-        $post: (option: { body: Methods3['post']['reqBody'], config?: T | undefined }) =>
-          fetch<Methods3['post']['resBody']>(prefix, PATH3, POST, option).json().then(r => r.body),
-        $path: () => `${prefix}${PATH3}`
+        post: (option: { body: Methods8['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods8['post']['resBody']>(prefix, PATH8, POST, option).json(),
+        $post: (option: { body: Methods8['post']['reqBody'], config?: T | undefined }) =>
+          fetch<Methods8['post']['resBody']>(prefix, PATH8, POST, option).json().then(r => r.body),
+        $path: () => `${prefix}${PATH8}`
       }
     }
   }

--- a/web/src/libs/api/match/after/send_result.ts
+++ b/web/src/libs/api/match/after/send_result.ts
@@ -1,0 +1,8 @@
+import { ReqSendResultType, ResSendResultType } from '../../../types/api';
+
+export type Methods = {
+  post: {
+    reqBody: ReqSendResultType;
+    resBody: ResSendResultType;
+  };
+};

--- a/web/src/libs/api/match/before/custom_match.ts
+++ b/web/src/libs/api/match/before/custom_match.ts
@@ -1,0 +1,8 @@
+import { ReqCustomMatchType, ResCustomMatchType } from '../../../types/api';
+
+export type Methods = {
+  post: {
+    reqBody: ReqCustomMatchType;
+    resBody: ResCustomMatchType;
+  };
+};

--- a/web/src/libs/api/match/before/delete_room.ts
+++ b/web/src/libs/api/match/before/delete_room.ts
@@ -1,0 +1,8 @@
+import { ReqDeleteRoomType, ResDeleteRoomType } from '../../../types/api';
+
+export type Methods = {
+  post: {
+    reqBody: ReqDeleteRoomType;
+    resBody: ResDeleteRoomType;
+  };
+};

--- a/web/src/libs/api/match/before/leave_user.ts
+++ b/web/src/libs/api/match/before/leave_user.ts
@@ -1,0 +1,8 @@
+import { ReqLeaveUserType, ResLeaveUserType } from '../../../types/api';
+
+export type Methods = {
+  post: {
+    reqBody: ReqLeaveUserType;
+    resBody: ResLeaveUserType;
+  };
+};

--- a/web/src/libs/api/match/before/random_match.ts
+++ b/web/src/libs/api/match/before/random_match.ts
@@ -1,0 +1,8 @@
+import { ReqRandomMatchType, ResRandomMatchType } from '../../../types/api';
+
+export type Methods = {
+  post: {
+    reqBody: ReqRandomMatchType;
+    resBody: ResRandomMatchType;
+  };
+};

--- a/web/src/libs/api/user/delete_user.ts
+++ b/web/src/libs/api/user/delete_user.ts
@@ -1,0 +1,8 @@
+import { ReqDeleteUserType, ResDeleteUserType } from '../../types/api';
+
+export type Methods = {
+  post: {
+    reqBody: ReqDeleteUserType;
+    resBody: ResDeleteUserType;
+  };
+};

--- a/web/src/libs/api/user/get_user_info.ts
+++ b/web/src/libs/api/user/get_user_info.ts
@@ -1,0 +1,8 @@
+import { ReqGetUserInfoType, ResGetUserInfoType } from '../../types/api';
+
+export type Methods = {
+  post: {
+    reqBody: ReqGetUserInfoType;
+    resBody: ResGetUserInfoType;
+  };
+};

--- a/web/src/libs/api/user/login.ts
+++ b/web/src/libs/api/user/login.ts
@@ -1,0 +1,8 @@
+import { ReqLoginUserType, ResLoginUserType } from '../../types/api';
+
+export type Methods = {
+  post: {
+    reqBody: ReqLoginUserType;
+    resBody: ResLoginUserType;
+  };
+};

--- a/web/src/libs/api/user/make_user.ts
+++ b/web/src/libs/api/user/make_user.ts
@@ -1,0 +1,8 @@
+import { ReqSignUpUserType, ResSignUpUserType } from '../../types/api';
+
+export type Methods = {
+  post: {
+    reqBody: ReqSignUpUserType;
+    resBody: ResSignUpUserType;
+  };
+};

--- a/web/src/libs/types/api.ts
+++ b/web/src/libs/types/api.ts
@@ -1,0 +1,20 @@
+// api/user/login
+export type ReqLoginUserType = {
+  user_name: String;
+  user_password: String;
+};
+export type ResLoginUserType = {
+  is_success: Boolean;
+  user_id: Number;
+  user_level: {
+    exp: Number;
+    level: Number;
+  };
+};
+
+// api/user/make_user
+export type SignUpUserType = {
+  is_success: Boolean;
+};
+
+// api/user/get_user_info

--- a/web/src/libs/types/api.ts
+++ b/web/src/libs/types/api.ts
@@ -13,8 +13,30 @@ export type ResLoginUserType = {
 };
 
 // api/user/make_user
-export type SignUpUserType = {
+export type ReqSignUpUserType = {
+  user_name: String;
+  user_password: String;
+};
+export type ResSignUpUserType = {
   is_success: Boolean;
 };
 
 // api/user/get_user_info
+export type ReqGetUserInfoType = {
+  user_id: Number;
+};
+export type ResGetUserInfoType = {
+  user_name: String;
+  user_level: {
+    exp: Number;
+    level: Number;
+  };
+};
+
+// api/user/delete_user
+export type ReqDeleteUserType = {
+  user_id: Number;
+};
+export type ResDeleteUserType = {
+  is_success: Boolean;
+};

--- a/web/src/libs/types/api.ts
+++ b/web/src/libs/types/api.ts
@@ -40,3 +40,48 @@ export type ReqDeleteUserType = {
 export type ResDeleteUserType = {
   is_success: Boolean;
 };
+
+// api/match/after/send_result
+export type ReqSendResultType = {
+  user_id: String;
+  result: Number;
+};
+export type ResSendResultType = {
+  is_success: Boolean;
+};
+
+// api/match/before/custom_match
+export type ReqCustomMatchType = {
+  user_id: Number;
+  game_id: String;
+};
+export type ResCustomMatchType = {
+  game_id: String;
+  is_full: Boolean;
+};
+
+// api/match/before/random_match
+export type ReqRandomMatchType = {
+  user_id: Number;
+};
+export type ResRandomMatchType = {
+  is_success: Boolean;
+  ready_member: Number;
+};
+
+// api/match/before/delete_room
+export type ReqDeleteRoomType = {
+  game_id: String;
+  user_id: Number;
+};
+export type ResDeleteRoomType = {
+  is_success: Boolean;
+};
+
+// api/match/before/leave_user
+export type ReqLeaveUserType = {
+  user_id: Number;
+};
+export type ResLeaveUserType = {
+  is_success: Boolean;
+};

--- a/web/src/libs/utils/apiClient.ts
+++ b/web/src/libs/utils/apiClient.ts
@@ -1,0 +1,5 @@
+import axios from 'axios';
+import aspida from '@aspida/axios';
+import api from '../api/$api';
+
+export const apiClient = api(aspida(axios, { baseURL: 'http://localhost:3000/api' }));

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aspida/fetch@^1.11.0":
+"@aspida/axios@^1.11.0":
   version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@aspida/fetch/-/fetch-1.11.0.tgz#19c3757f07ad8e42575253cad8ced0ff064628fa"
-  integrity sha512-ISi67d6YIL9thIXvbq6ac0UYAtcojILCiOEbjhCky55uyoGHV7z+ISgwzUf7X8CxTdY8iXiimcz6AMNtBfdiyw==
+  resolved "https://registry.yarnpkg.com/@aspida/axios/-/axios-1.11.0.tgz#66157bb003460ed9a02c4f1607fb0ce388d1894e"
+  integrity sha512-tsxkqCQPmPHlqVPW0BYwR7tHmmxbk8yEpOb6gn9bnqCe5riBDHLUiiWlde5+gSjWQAxx/TJ9AAlyciaL84vylw==
   dependencies:
     aspida "^1.7.1"
 
@@ -3626,6 +3626,15 @@ axe-core@^4.4.3:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.6.1.tgz#79cccdee3e3ab61a8f42c458d4123a6768e6fbce"
   integrity sha512-lCZN5XRuOnpG4bpMq8v0khrWtUOn+i8lZSb6wHZH56ZfbIEv6XwJV84AAueh9/zi7qPVJ/E4yz6fmsiyOmXR4w==
 
+axios@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.4.tgz#f5760cefd9cfb51fd2481acf88c05f67c4523024"
+  integrity sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -5842,6 +5851,11 @@ focus-lock@^0.8.0:
   integrity sha512-/LFZOIo82WDsyyv7h7oc0MJF9ACOvDRdx9rWPZ2pgMfNWu/z8hQDBtOchuB/0BVLmuFOZjV02YwUVzNsWx/EzA==
   dependencies:
     tslib "^1.9.3"
+
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -8898,6 +8912,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -10,6 +10,13 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@aspida/fetch@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@aspida/fetch/-/fetch-1.11.0.tgz#19c3757f07ad8e42575253cad8ced0ff064628fa"
+  integrity sha512-ISi67d6YIL9thIXvbq6ac0UYAtcojILCiOEbjhCky55uyoGHV7z+ISgwzUf7X8CxTdY8iXiimcz6AMNtBfdiyw==
+  dependencies:
+    aspida "^1.7.1"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.18.6", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -2683,6 +2690,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
+"@types/minimist@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
+  integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
 "@types/node-fetch@^2.5.7":
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
@@ -3536,6 +3548,16 @@ asn1.js@^5.2.0:
     minimalistic-assert "^1.0.0"
     safer-buffer "^2.1.0"
 
+aspida@^1.7.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/aspida/-/aspida-1.11.0.tgz#a01f75ed3c85929de592afc71802fa1c689a3b7d"
+  integrity sha512-TVQ4bKJQ5nLm6GCZRIzBA8fQe7AhilYkpsQWg0DeBNKm2u7kbulxyCD8xXOqs41Xkrt+jNG7/GGkkseDPgUSOQ==
+  dependencies:
+    "@types/minimist" "^1.2.2"
+    chokidar "^3.5.3"
+    form-data "^4.0.0"
+    minimist "^1.2.6"
+
 assert@^1.1.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
@@ -4165,7 +4187,7 @@ character-reference-invalid@^1.0.0:
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
   integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
-"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.4.2:
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -5877,6 +5899,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"


### PR DESCRIPTION
aspidaを導入して、クライアントサイドのエンドポイントの型を定義しました。

以下のようにすれば、apiをフロント側から簡単に呼び出すことができます。
api/user/delete_userを呼び出す例
```
import { apiClient } from '@src/libs/utils/apiClient'

apiClient.user.delete_user.$post({user_name, user_password})
.then()
.cacth()
```

参考
https://zenn.dev/solufa/articles/getting-started-with-aspida#next.js%E3%81%A7%E4%BD%BF%E3%81%A3%E3%81%A6%E3%81%BF%E3%82%88%E3%81%86
https://dev.classmethod.jp/articles/vercel-microcms-nextjs-blog/#toc-6