### PR TITLE
API仕様書定義

### DIFF
--- a/schema/openAPI.yaml
+++ b/schema/openAPI.yaml
@@ -1,0 +1,144 @@
+swagger: "2.0"
+info:
+  version: "1.0"
+  title: CODE_DUEL API
+  description: CODE_DUELのAPI仕様書です。
+  contact:
+    name: CODE_DUEL
+schemes:
+  - https
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /deck:
+    get:
+      tags:
+        - decks
+      summary: デッキ一覧を取得する
+      description: デッキ一覧を取得する
+      operationId: getDecks
+      responses:
+        200:
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Deck"
+  /draw:
+    get:
+      tags:
+        - cards
+      summary: カードを引く
+      description: 必要な枚数だけカードを引く
+      operationId: drawCard
+      parameters:
+        - name: count
+          in: query
+          description: 必要なカードの枚数
+          required: true
+          type: number
+      responses:
+        200:
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/card"
+  /cards:
+    get:
+      tags:
+        - cards
+      summary: カード一覧を取得する
+      description: カード一覧を取得する
+      operationId: getCards
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/cards"
+  /cards/{id}:
+    get:
+      tags:
+        - cards
+      summary: カードを取得する
+      description: カードを取得する
+      operationId: getCard
+      parameters:
+        - name: id
+          in: path
+          description: カードのID
+          required: true
+          type: number
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/card"
+  /combo:
+    get:
+      tags:
+        - combos
+      summary: コンボを取得する
+      description: コンボを取得する
+      operationId: getCombo
+      parameters:
+        - name: cards
+          in: query
+          description: カードのID
+          required: true
+          type: array
+          items:
+            type: number
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/combo"
+
+definitions:
+  Deck:
+    title: Deck
+    type: object
+    properties:
+      name:
+        type: string
+      cards:
+        type: array
+        items:
+          $ref: "#/definitions/card"
+  card:
+    title: card
+    type: object
+    properties:
+      name:
+        type: string
+      value:
+        type: integer
+      type:
+        type: string
+        enum: [attack, heal, absorption]
+      combo:
+        type: array
+  cards:
+    title: cards
+    type: array
+    items:
+      $ref: "#/definitions/card"
+  combo:
+    title: combo
+    type: object
+    properties:
+      name:
+        type: string
+      cards:
+        type: array
+        items:
+          $ref: "#/definitions/card"
+
+tags:
+  - name: cards
+  - name: decks
+  - name: combos
+responses: {}

--- a/schema/socket.ts
+++ b/schema/socket.ts
@@ -1,0 +1,56 @@
+interface ServerToClientEvents {
+  successRandomMatching: (
+    room_id: number,
+    user1_id: number,
+    user2_id: number
+  ) => void;
+  updateField: (
+    turn: number,
+    os: osType,
+    combo: ComboType | null,
+    cardsData: Array<CardType>,
+    playersData: Array<PlayerType>
+  ) => void;
+  gameStart: (turn: number, user1: PlayerType, user2: PlayerType) => void;
+}
+
+interface ClientToServerEvents {
+  enterWaitingRoom: (
+    user_id: number | undefined,
+    user_name: string | undefined
+  ) => void;
+  exitWaitingRoom: (
+    user_id: number | undefined,
+    user_name: string | undefined
+  ) => void;
+  readyGameStart: (user: PlayerType) => void;
+  joinRoom: (game_id: string, opponent_id: number) => void;
+  sendCards: (
+    game_id: string | undefined,
+    combo: ComboType | null,
+    cards: Array<CardType>
+  ) => void;
+}
+
+type attackType = "attack" | "heal" | "absorption";
+type osType = "windows" | "mac" | "linux";
+
+interface ComboType {
+  id: number;
+  name: string;
+  type: attackType;
+  value: number;
+}
+
+interface CardType {
+  id: number;
+  name: string;
+  type: attackType;
+  value: number;
+}
+
+interface PlayerType {
+  id: number;
+  name: string;
+  hp: number;
+}

--- a/schema/socket.ts
+++ b/schema/socket.ts
@@ -11,22 +11,17 @@ interface ServerToClientEvents {
     cardsData: Array<CardType>,
     playersData: Array<PlayerType>
   ) => void;
-  gameStart: (turn: number, user1: PlayerType, user2: PlayerType) => void;
-  gameFinish: (winner: number, loser: number) => void;
+  startGame: (turn: number, user1: PlayerType, user2: PlayerType) => void;
+  finishGame: (winner: number, loser: number) => void;
 }
 
 interface ClientToServerEvents {
-  enterWaitingRoom: (
-    user_id: number | undefined,
-    user_name: string | undefined
-  ) => void;
-  exitWaitingRoom: (
-    user_id: number | undefined,
-    user_name: string | undefined
-  ) => void;
-  enterPlayingRoom: (user: PlayerType) => void;
+  enterWaitingRoom: (user_id: number, user_name: string) => void;
+  exitWaitingRoom: (user_id: number, user_name: string) => void;
+  enterPlayingRoom: (room_id: number, user: PlayerType) => void;
+  exitPlayingRoom: (room_id: number, user: PlayerType) => void;
   sendCards: (
-    game_id: string | undefined,
+    room_id: number,
     combo: ComboType | null,
     cards: Array<CardType>
   ) => void;

--- a/schema/socket.ts
+++ b/schema/socket.ts
@@ -24,8 +24,7 @@ interface ClientToServerEvents {
     user_id: number | undefined,
     user_name: string | undefined
   ) => void;
-  readyGameStart: (user: PlayerType) => void;
-  joinRoom: (game_id: string, opponent_id: number) => void;
+  enterPlayingRoom: (user: PlayerType) => void;
   sendCards: (
     game_id: string | undefined,
     combo: ComboType | null,

--- a/schema/socket.ts
+++ b/schema/socket.ts
@@ -12,6 +12,7 @@ interface ServerToClientEvents {
     playersData: Array<PlayerType>
   ) => void;
   gameStart: (turn: number, user1: PlayerType, user2: PlayerType) => void;
+  gameFinish: (winner: number, loser: number) => void;
 }
 
 interface ClientToServerEvents {

--- a/schema/socket.ts
+++ b/schema/socket.ts
@@ -5,14 +5,15 @@ interface ServerToClientEvents {
     user2_id: number
   ) => void;
   updateField: (
-    turn: number,
+    round: number,
+    turn: number, // player id
     os: osType,
     combo: ComboType | null,
     cardsData: Array<CardType>,
     playersData: Array<PlayerType>
   ) => void;
   startGame: (turn: number, user1: PlayerType, user2: PlayerType) => void;
-  finishGame: (winner: number, loser: number) => void;
+  finishGame: (winner: number, loser: number /* player id **/) => void;
 }
 
 interface ClientToServerEvents {


### PR DESCRIPTION
#69 

## やったこと
openAPIを使ってAPIの仕様の定義をしました。

## 懸念点
### 最初のカードのドローについて
コンボ情報もまとめて送る想定とslackに言いましたがやめました。
最初のカードのドローではカードの情報だけを取得する様にしています。
comboに関しては、fieldなどに置いた時にカードのidを送ってコンボ情報を返す想定です。

大量にリクエストが送られないかという懸念があるが、同じリクエストはreactの`useMemo`とかを使えば防げるので大丈夫だと思ってる。

最初に全てのコンボ情報を送るだと、フロントエンド側でコンボの判定をしなくてはいけなくなるという問題があったが、この実装によってコンボの判定もバックエンドに送ることができた。


## レビュワーの人へ
先に #73 のsocketに関するPRを見て欲しいです。
レビューはこのブランチを取り込んで、swaggerのプレビューを見てもらうといいと思います。

