### PR TITLE
API, Socketの定義の変更

### DIFF
--- a/schema/openAPI.yaml
+++ b/schema/openAPI.yaml
@@ -1,4 +1,4 @@
-swagger: "2.0"
+swagger: "3.0"
 info:
   version: "1.0"
   title: CODE_DUEL API
@@ -12,6 +12,44 @@ consumes:
 produces:
   - application/json
 paths:
+  /signUp:
+    post:
+      tags:
+        - user
+      summary: ユーザー登録
+      description: ユーザーの登録を行う。初回アクセス時のみフロントからリクエストが送られる。
+      operationId: signUp
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              user_id:
+                type: number
+  /signIn:
+    post:
+      tags:
+        - user
+      summary: ユーザーログイン
+      description: ログインを行う。ブラウザにidが保存されている場合にリクエストが送られる。
+      operationId: signIn
+      requestBody:
+        content: application/json
+        schema:
+          type: object
+          properties:
+            user_id:
+              type: number
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              user_id:
+                type: number
+
   /deck:
     get:
       tags:
@@ -34,7 +72,12 @@ paths:
       description: 必要な枚数だけカードを引く
       operationId: drawCard
       parameters:
-        - name: count
+        - name: deck_id
+          in: query
+          description: デッキのID
+          required: true
+          type: number
+        - name: card_count
           in: query
           description: 必要なカードの枚数
           required: true
@@ -119,8 +162,6 @@ definitions:
       type:
         type: string
         enum: [attack, heal, absorption]
-      combo:
-        type: array
   cards:
     title: cards
     type: array
@@ -136,8 +177,14 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/card"
+      type:
+        type: string
+        enum: [attack, heal, absorption]
+      value:
+        type: integer
 
 tags:
+  - name: user
   - name: cards
   - name: decks
   - name: combos

--- a/schema/openAPI.yaml
+++ b/schema/openAPI.yaml
@@ -11,6 +11,16 @@ paths:
       summary: ユーザー登録
       description: ユーザーの登録を行う。初回アクセス時のみフロントからリクエストが送られる。
       operationId: signUp
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user_id:
+                  type: number
+                user_name:
+                  type: string
       responses:
         200:
           description: OK
@@ -33,6 +43,8 @@ paths:
               properties:
                 user_id:
                   type: number
+                user_name:
+                  type: string
       responses:
         200:
           description: OK

--- a/schema/openAPI.yaml
+++ b/schema/openAPI.yaml
@@ -64,31 +64,6 @@ paths:
             type: array
             items:
               $ref: "#/definitions/Deck"
-  /draw:
-    get:
-      tags:
-        - cards
-      summary: カードを引く
-      description: 必要な枚数だけカードを引く
-      operationId: drawCard
-      parameters:
-        - name: deck_id
-          in: query
-          description: デッキのID
-          required: true
-          type: number
-        - name: card_count
-          in: query
-          description: 必要なカードの枚数
-          required: true
-          type: number
-      responses:
-        200:
-          description: OK
-          schema:
-            type: array
-            items:
-              $ref: "#/definitions/card"
   /cards:
     get:
       tags:

--- a/schema/openAPI.yaml
+++ b/schema/openAPI.yaml
@@ -1,16 +1,8 @@
-swagger: "3.0"
+openapi: "3.0.0"
 info:
   version: "1.0"
   title: CODE_DUEL API
   description: CODE_DUELのAPI仕様書です。
-  contact:
-    name: CODE_DUEL
-schemes:
-  - https
-consumes:
-  - application/json
-produces:
-  - application/json
 paths:
   /signUp:
     post:
@@ -22,11 +14,10 @@ paths:
       responses:
         200:
           description: OK
-          schema:
-            type: object
-            properties:
-              user_id:
-                type: number
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/user"
   /signIn:
     post:
       tags:
@@ -35,21 +26,20 @@ paths:
       description: ログインを行う。ブラウザにidが保存されている場合にリクエストが送られる。
       operationId: signIn
       requestBody:
-        content: application/json
-        schema:
-          type: object
-          properties:
-            user_id:
-              type: number
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user_id:
+                  type: number
       responses:
         200:
           description: OK
-          schema:
-            type: object
-            properties:
-              user_id:
-                type: number
-
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/user"
   /deck:
     get:
       tags:
@@ -60,10 +50,12 @@ paths:
       responses:
         200:
           description: OK
-          schema:
-            type: array
-            items:
-              $ref: "#/definitions/Deck"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/deck"
   /cards:
     get:
       tags:
@@ -74,8 +66,12 @@ paths:
       responses:
         200:
           description: OK
-          schema:
-            $ref: "#/definitions/cards"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/card"
   /cards/{id}:
     get:
       tags:
@@ -88,12 +84,15 @@ paths:
           in: path
           description: カードのID
           required: true
-          type: number
+          schema:
+            type: integer
       responses:
         200:
           description: OK
-          schema:
-            $ref: "#/definitions/card"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/card"
   /combo:
     get:
       tags:
@@ -106,61 +105,68 @@ paths:
           in: query
           description: カードのID
           required: true
-          type: array
-          items:
-            type: number
+          schema:
+            type: array
+            items:
+              type: integer
       responses:
         200:
           description: OK
-          schema:
-            $ref: "#/definitions/combo"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/combo"
 
-definitions:
-  Deck:
-    title: Deck
-    type: object
-    properties:
-      name:
-        type: string
-      cards:
-        type: array
-        items:
-          $ref: "#/definitions/card"
-  card:
-    title: card
-    type: object
-    properties:
-      name:
-        type: string
-      value:
-        type: integer
-      type:
-        type: string
-        enum: [attack, heal, absorption]
-  cards:
-    title: cards
-    type: array
-    items:
-      $ref: "#/definitions/card"
-  combo:
-    title: combo
-    type: object
-    properties:
-      name:
-        type: string
-      cards:
-        type: array
-        items:
-          $ref: "#/definitions/card"
-      type:
-        type: string
-        enum: [attack, heal, absorption]
-      value:
-        type: integer
-
-tags:
-  - name: user
-  - name: cards
-  - name: decks
-  - name: combos
-responses: {}
+components:
+  schemas:
+    user:
+      title: user
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    deck:
+      title: deck
+      type: object
+      properties:
+        name:
+          type: string
+        cards:
+          type: array
+          items:
+            $ref: "#/components/schemas/card"
+    card:
+      title: card
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: integer
+        type:
+          type: string
+          enum: [attack, heal, absorption]
+    cards:
+      title: cards
+      type: array
+      items:
+        $ref: "#/components/schemas/card"
+    combo:
+      title: combo
+      type: object
+      properties:
+        name:
+          type: string
+        cards:
+          type: array
+          items:
+            $ref: "#/components/schemas/card"
+        type:
+          type: string
+          enum: [attack, heal, absorption]
+        value:
+          type: integer

--- a/schema/socket.ts
+++ b/schema/socket.ts
@@ -5,12 +5,14 @@ interface ServerToClientEvents {
     player2_id: number
   ) => void;
   updateField: (
+    // 攻撃を受けてゲームの情報が更新されたときに呼ばれる
     round: number,
     turn: number, // player id
     os: osType,
     combo: ComboType | null,
     cardsData: Array<CardType>,
-    playersData: Array<PlayerType>
+    myPlayerData: MyPlayerType, // ここでカードのドローを行う。
+    opponentPlayerData: PlayerType
   ) => void;
   startGame: (turn: number, player1: PlayerType, player2: PlayerType) => void;
   finishGame: (winner: number, loser: number /* player id **/) => void;
@@ -32,22 +34,27 @@ interface ClientToServerEvents {
 type attackType = "attack" | "heal" | "absorption";
 type osType = "windows" | "mac" | "linux";
 
-interface ComboType {
+type ComboType = {
   id: number;
   name: string;
   type: attackType;
   value: number;
-}
+};
 
-interface CardType {
+type CardType = {
   id: number;
   name: string;
   type: attackType;
   value: number;
-}
+};
 
-interface PlayerType {
+type PlayerType = {
   id: number;
   name: string;
   hp: number;
-}
+  deck: number;
+};
+// 相手のカードが見えないようにするために、MyPlayerTypeを定義
+type MyPlayerType = PlayerType & {
+  hand: Array<CardType>;
+};

--- a/schema/socket.ts
+++ b/schema/socket.ts
@@ -1,8 +1,8 @@
 interface ServerToClientEvents {
   successRandomMatching: (
     room_id: number,
-    user1_id: number,
-    user2_id: number
+    player1_id: number,
+    player2_id: number
   ) => void;
   updateField: (
     round: number,
@@ -12,18 +12,18 @@ interface ServerToClientEvents {
     cardsData: Array<CardType>,
     playersData: Array<PlayerType>
   ) => void;
-  startGame: (turn: number, user1: PlayerType, user2: PlayerType) => void;
+  startGame: (turn: number, player1: PlayerType, player2: PlayerType) => void;
   finishGame: (winner: number, loser: number /* player id **/) => void;
 }
 
 interface ClientToServerEvents {
-  enterWaitingRoom: (user_id: number, user_name: string) => void;
-  exitWaitingRoom: (user_id: number, user_name: string) => void;
-  enterPlayingRoom: (room_id: number, user: PlayerType) => void;
-  exitPlayingRoom: (room_id: number, user: PlayerType) => void;
+  enterWaitingRoom: (player_id: number, player_name: string) => void;
+  exitWaitingRoom: (player_id: number, player_name: string) => void;
+  enterPlayingRoom: (room_id: number, player: PlayerType) => void;
+  exitPlayingRoom: (room_id: number, player: PlayerType) => void;
   sendCards: (
     room_id: number,
-    user_id: number,
+    player_id: number,
     combo: ComboType | null,
     cards: Array<CardType>
   ) => void;

--- a/schema/socket.ts
+++ b/schema/socket.ts
@@ -5,15 +5,15 @@ interface ServerToClientEvents {
     player2_id: number
   ) => void;
   updateField: (
-    // 攻撃を受けてゲームの情報が更新されたときに呼ばれる
+    // 攻撃を受けてゲームの情報が更新されたときに、ルーム全体に対して呼ばれる
     round: number,
     turn: number, // player id
     os: osType,
     combo: ComboType | null,
     cardsData: Array<CardType>,
-    myPlayerData: MyPlayerType, // ここでカードのドローを行う。
-    opponentPlayerData: PlayerType
+    playersData: Array<PlayerType>
   ) => void;
+  drawCards: (cards: Array<CardType>) => void; // 新しく自分のターンになった時に、自分のターンになった人に対して呼ばれる
   startGame: (turn: number, player1: PlayerType, player2: PlayerType) => void;
   finishGame: (winner: number, loser: number /* player id **/) => void;
 }
@@ -53,8 +53,4 @@ type PlayerType = {
   name: string;
   hp: number;
   deck: number;
-};
-// 相手のカードが見えないようにするために、MyPlayerTypeを定義
-type MyPlayerType = PlayerType & {
-  hand: Array<CardType>;
 };


### PR DESCRIPTION
## 関連issue
#75 

## やったこと
DB設計の変更に合わせて、Socket, API仕様書の変更をしました。
- ユーザーのサインアップ/ログインのエンドポイントを追加
- カードドローの処理をAPIからsocketに変更

## 懸念点
カードのドローの時に全てのカードを送信するか、ドローされたカードだけを送信するか。
フロント側では正直どちらでもいい...