### PR TITLE
DBを永続化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+data

--- a/db/init/init.sql
+++ b/db/init/init.sql
@@ -3,7 +3,7 @@ CREATE DATABASE codeduel;
 -- 作成したDBに接続
 \c codeduel;
 
-INSERT INTO "OS" VALUES(1, 'testOS', 'testPath')
+INSERT INTO "OS" VALUES(1, 'testOS', 'testPath');
 INSERT INTO "Card" VALUES(1, 1, 'sample1', 100, 'ATTACK', 'hoge');
 INSERT INTO "Card" VALUES(2, 1, 'sample2', 200, 'HEAL', 'fuga');
 INSERT INTO "Card" VALUES(3, 1, 'sample3', 300, 'ABSORPTION', 'huge');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - TZ=${TZ}
       - CHOKIDAR_USEPOLLING=true
     volumes:
+      - ./db/data:/var/lib/postgresql/data
       - ./db/init:/docker-entrypoint-initdb.d
     ports:
       - '5432:5432'


### PR DESCRIPTION
## 要点
docker compose downしたときにDBのデータが空になる問題があったため修正

### 追加機能
docker-compose.ymlの修正
db/dataにpostgresqlのデータを保存するように変更

### 申し送り事項
dataをgitignoreしてるので、それぞれの環境で一度migrateしてください。そうするとデータがdbに入って消えなくなります。